### PR TITLE
feat: add rename feature for Beancount LSP

### DIFF
--- a/.cursor/rules/nedb.mdc
+++ b/.cursor/rules/nedb.mdc
@@ -1,0 +1,8 @@
+---
+description: 
+globs: 
+---
+nedb has many bugs, don't use index feature and `removeAsync` from nedb(Storage). Instead use the `remove` function.
+
+- removeAsync will occur RangeError: Maximum call stack size exceeded
+- Index feature will lose data

--- a/packages/lsp-server/src/common/features/position-utils.ts
+++ b/packages/lsp-server/src/common/features/position-utils.ts
@@ -1,0 +1,228 @@
+import { Logger } from '@bean-lsp/shared';
+import * as lsp from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { asLspRange } from '../common';
+import { Trees } from '../trees';
+
+// Create a logger for position utilities
+const logger = new Logger('position-utils');
+
+/**
+ * Gets the range of a node at a specific position
+ */
+export async function getRangeAtPosition(
+	trees: Trees,
+	document: TextDocument,
+	position: lsp.Position,
+): Promise<lsp.Range> {
+	const tree = await trees.getParseTree(document);
+	if (!tree) {
+		throw new Error(`Failed to get parse tree for document: ${document.uri}`);
+	}
+
+	// Get the node at the current position
+	const offset = document.offsetAt(position);
+	const node = tree.rootNode.descendantForIndex(offset);
+
+	if (!node) {
+		// 如果找不到节点，返回一个基于当前位置的默认范围
+		return {
+			start: position,
+			end: {
+				line: position.line,
+				character: position.character + 1,
+			},
+		};
+	}
+
+	// 使用asLspRange函数创建Range
+	return asLspRange(node);
+}
+
+/**
+ * Extracts the account name at the given position
+ */
+export async function getAccountAtPosition(
+	trees: Trees,
+	document: TextDocument,
+	position: lsp.Position,
+): Promise<string | null> {
+	const tree = await trees.getParseTree(document);
+	if (!tree) {
+		logger.warn(`Failed to get parse tree for document: ${document.uri}`);
+		return null;
+	}
+
+	// Get the node at the current position
+	const offset = document.offsetAt(position);
+	const node = tree.rootNode.descendantForIndex(offset);
+
+	if (!node) {
+		return null;
+	}
+
+	// Check if we're in an account node
+	if (
+		node.type === 'account'
+		|| node.text.match(/^(Assets|Liabilities|Equity|Income|Expenses)(:[A-Z0-9][A-Za-z0-9-]*)*$/)
+	) {
+		return node.text;
+	}
+
+	// For parent nodes that might contain an account
+	if (node.parent && node.parent.type === 'account') {
+		return node.parent.text;
+	}
+
+	return null;
+}
+
+/**
+ * Extracts the commodity name at the given position
+ */
+export async function getCommodityAtPosition(
+	trees: Trees,
+	document: TextDocument,
+	position: lsp.Position,
+): Promise<string | null> {
+	const tree = await trees.getParseTree(document);
+	if (!tree) {
+		logger.warn(`Failed to get parse tree for document: ${document.uri}`);
+		return null;
+	}
+
+	// Get the node at the current position
+	const offset = document.offsetAt(position);
+	const node = tree.rootNode.descendantForIndex(offset);
+
+	if (!node) {
+		return null;
+	}
+
+	// Check if we're in a currency node
+	if (node.type === 'currency') {
+		return node.text;
+	}
+
+	// For parent nodes that might contain a currency
+	if (node.parent && node.parent.type === 'currency') {
+		return node.parent.text;
+	}
+
+	// Check for text that looks like a currency (typically uppercase 2-5 letter codes)
+	if (node.text.match(/^[A-Z]{2,5}$/)) {
+		return node.text;
+	}
+
+	return null;
+}
+
+/**
+ * Extracts the tag name at the given position
+ */
+export async function getTagAtPosition(
+	trees: Trees,
+	document: TextDocument,
+	position: lsp.Position,
+): Promise<string | null> {
+	const tree = await trees.getParseTree(document);
+	if (!tree) {
+		logger.warn(`Failed to get parse tree for document: ${document.uri}`);
+		return null;
+	}
+
+	// Get the node at the current position
+	const offset = document.offsetAt(position);
+	const node = tree.rootNode.descendantForIndex(offset);
+
+	if (!node) {
+		return null;
+	}
+
+	// Check if we're in a tag node
+	if (node.type === 'tag') {
+		return node.text.substring(1); // Remove the # prefix
+	}
+
+	// For parent nodes that might contain a tag
+	if (node.parent && node.parent.type === 'tag') {
+		return node.parent.text.substring(1); // Remove the # prefix
+	}
+
+	// Check for text that looks like a tag (starts with #)
+	if (node.text.startsWith('#')) {
+		return node.text.substring(1);
+	}
+
+	return null;
+}
+
+/**
+ * Extracts the payee name at the given position
+ */
+export async function getPayeeAtPosition(
+	trees: Trees,
+	document: TextDocument,
+	position: lsp.Position,
+): Promise<string | null> {
+	const tree = await trees.getParseTree(document);
+	if (!tree) {
+		logger.warn(`Failed to get parse tree for document: ${document.uri}`);
+		return null;
+	}
+
+	// Get the node at the current position
+	const offset = document.offsetAt(position);
+	const node = tree.rootNode.descendantForIndex(offset);
+
+	if (!node) {
+		return null;
+	}
+
+	// Check if we're in a payee node
+	if (node.type === 'payee') {
+		return node.text.replace(/^"|"$/g, ''); // Remove quotes
+	}
+
+	// For parent nodes that might contain a payee
+	if (node.parent && node.parent.type === 'payee') {
+		return node.parent.text.replace(/^"|"$/g, ''); // Remove quotes
+	}
+
+	return null;
+}
+
+/**
+ * Extracts the narration text at the given position
+ */
+export async function getNarrationAtPosition(
+	trees: Trees,
+	document: TextDocument,
+	position: lsp.Position,
+): Promise<string | null> {
+	const tree = await trees.getParseTree(document);
+	if (!tree) {
+		logger.warn(`Failed to get parse tree for document: ${document.uri}`);
+		return null;
+	}
+
+	// Get the node at the current position
+	const offset = document.offsetAt(position);
+	const node = tree.rootNode.descendantForIndex(offset);
+
+	if (!node) {
+		return null;
+	}
+
+	// Check if we're in a narration node
+	if (node.type === 'narration') {
+		return node.text.replace(/^"|"$/g, ''); // Remove quotes
+	}
+
+	// For parent nodes that might contain a narration
+	if (node.parent && node.parent.type === 'narration') {
+		return node.parent.text.replace(/^"|"$/g, ''); // Remove quotes
+	}
+
+	return null;
+}

--- a/packages/lsp-server/src/common/features/rename.ts
+++ b/packages/lsp-server/src/common/features/rename.ts
@@ -1,0 +1,167 @@
+import { Logger } from '@bean-lsp/shared';
+import * as lsp from 'vscode-languageserver';
+import { DocumentStore } from '../document-store';
+import { Trees } from '../trees';
+import * as positionUtils from './position-utils';
+import { ReferencesFeature } from './references';
+import { SymbolIndex } from './symbol-index';
+
+// Create a logger for the rename module
+const logger = new Logger('rename');
+
+/**
+ * Provides rename functionality for the Beancount Language Server.
+ * This feature handles renaming symbols (accounts, commodities, tags, etc.) across files.
+ */
+export class RenameFeature {
+	private references: ReferencesFeature;
+
+	constructor(
+		private readonly documents: DocumentStore,
+		private readonly trees: Trees,
+		private readonly symbolIndex: SymbolIndex,
+	) {
+		// Create a references feature to use for finding all references
+		this.references = new ReferencesFeature(documents, trees, symbolIndex);
+	}
+
+	/**
+	 * Registers the rename handlers with the language server connection
+	 */
+	register(connection: lsp.Connection): void {
+		connection.onPrepareRename((params) => this.onPrepareRename(params));
+		connection.onRenameRequest((params) => this.onRename(params));
+	}
+
+	/**
+	 * Validates if the symbol at the current position can be renamed
+	 */
+	private async onPrepareRename(
+		params: lsp.PrepareRenameParams,
+	): Promise<lsp.Range | { range: lsp.Range; placeholder: string } | null> {
+		logger.debug(`Prepare rename requested at position: ${JSON.stringify(params.position)}`);
+
+		const document = this.documents.get(params.textDocument.uri);
+		if (!document) {
+			logger.warn(`Document not found: ${params.textDocument.uri}`);
+			return null;
+		}
+
+		// Get relevant symbol at position using helper methods
+		// Check for account at position
+		const accountAtPosition = await positionUtils.getAccountAtPosition(this.trees, document, params.position);
+		if (accountAtPosition) {
+			logger.debug(`Found renamable account at position: ${accountAtPosition}`);
+			const range = await positionUtils.getRangeAtPosition(this.trees, document, params.position);
+			return {
+				range,
+				placeholder: accountAtPosition,
+			};
+		}
+
+		// Check for commodity at position
+		const commodityAtPosition = await positionUtils.getCommodityAtPosition(this.trees, document, params.position);
+		if (commodityAtPosition) {
+			logger.debug(`Found renamable commodity at position: ${commodityAtPosition}`);
+			const range = await positionUtils.getRangeAtPosition(this.trees, document, params.position);
+			return {
+				range,
+				placeholder: commodityAtPosition,
+			};
+		}
+
+		// Check for tag at position
+		const tagAtPosition = await positionUtils.getTagAtPosition(this.trees, document, params.position);
+		if (tagAtPosition) {
+			logger.debug(`Found renamable tag at position: ${tagAtPosition}`);
+			const range = await positionUtils.getRangeAtPosition(this.trees, document, params.position);
+			return {
+				range,
+				placeholder: tagAtPosition,
+			};
+		}
+
+		// Check for payee at position
+		const payeeAtPosition = await positionUtils.getPayeeAtPosition(this.trees, document, params.position);
+		if (payeeAtPosition) {
+			logger.debug(`Found renamable payee at position: ${payeeAtPosition}`);
+			const range = await positionUtils.getRangeAtPosition(this.trees, document, params.position);
+			return {
+				range,
+				placeholder: payeeAtPosition,
+			};
+		}
+
+		// Check for narration at position
+		const narrationAtPosition = await positionUtils.getNarrationAtPosition(this.trees, document, params.position);
+		if (narrationAtPosition) {
+			logger.debug(`Found renamable narration at position: ${narrationAtPosition}`);
+			const range = await positionUtils.getRangeAtPosition(this.trees, document, params.position);
+			return {
+				range,
+				placeholder: narrationAtPosition,
+			};
+		}
+
+		logger.debug('No renamable symbol found at the current position');
+		return null;
+	}
+
+	/**
+	 * Handles the actual rename request
+	 */
+	private async onRename(
+		params: lsp.RenameParams,
+	): Promise<lsp.WorkspaceEdit | null> {
+		logger.debug(`Rename requested at position: ${JSON.stringify(params.position)} to "${params.newName}"`);
+
+		const document = this.documents.get(params.textDocument.uri);
+		if (!document) {
+			logger.warn(`Document not found: ${params.textDocument.uri}`);
+			return null;
+		}
+
+		// First, find all references to the symbol being renamed
+		// We can piggyback on the ReferencesFeature's onReferences method
+		const referencesParams: lsp.ReferenceParams = {
+			textDocument: params.textDocument,
+			position: params.position,
+			context: { includeDeclaration: true },
+		};
+
+		const references = await this.references.onReferences(referencesParams);
+
+		if (!references || references.length === 0) {
+			logger.warn('No references found for renaming');
+			return null;
+		}
+
+		// 使用Map来避免未定义错误
+		const editsMap = new Map<string, lsp.TextEdit[]>();
+
+		// 为每个引用创建文本编辑
+		references.forEach(ref => {
+			const uri = ref.uri;
+			if (!editsMap.has(uri)) {
+				editsMap.set(uri, []);
+			}
+
+			// 通过get方法获取数组，TypeScript能确保它不是undefined
+			const edits = editsMap.get(uri)!;
+			edits.push({
+				range: ref.range,
+				newText: params.newName,
+			});
+		});
+
+		// 将Map转换为LSP需要的格式
+		const changes: { [uri: string]: lsp.TextEdit[] } = {};
+		editsMap.forEach((edits, uri) => {
+			changes[uri] = edits;
+		});
+
+		logger.debug(`Rename will update ${Object.keys(changes).length} files and ${references.length} occurrences`);
+
+		return { changes };
+	}
+}

--- a/packages/lsp-server/src/common/features/symbol-extractors.ts
+++ b/packages/lsp-server/src/common/features/symbol-extractors.ts
@@ -1,12 +1,8 @@
-import { Logger } from '@bean-lsp/shared';
 import * as lsp from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { asLspRange, compactToRange, rangeToCompact } from '../common';
 import { TreeQuery } from '../language';
 import { Trees } from '../trees';
-
-// Create a logger for the symbol extractors module
-const logger = new Logger('symbol-extractors');
 
 export interface SymbolInfo {
 	_symType: string;
@@ -77,8 +73,6 @@ export async function getPayees(doc: TextDocument, trees: Trees): Promise<Symbol
 	}
 	const query = TreeQuery.getQueryByTokenName('payee');
 	const captures = await query.captures(tree.rootNode);
-	logger.debug(`[symbol-extractors] Payees parse tree: ${tree.rootNode.toString()}`);
-	logger.debug(`[symbol-extractors] Payees captures: ${captures.length} matches`);
 	const result: SymbolInfo[] = [];
 	for (const capture of captures) {
 		const name = capture.node.text.replace(/^"|"$/g, ''); // Remove quotes

--- a/packages/lsp-server/src/common/startServer.ts
+++ b/packages/lsp-server/src/common/startServer.ts
@@ -13,6 +13,7 @@ import { DefinitionFeature } from './features/definitions';
 import { DocumentSymbolsFeature } from './features/document-symbols';
 import { FoldingRangeFeature } from './features/folding-ranges';
 import { ReferencesFeature } from './features/references';
+import { RenameFeature } from './features/rename';
 import { SelectionRangesFeature } from './features/selection-ranges';
 import { SemanticTokenFeature } from './features/semantic-token';
 import { Feature } from './features/types';
@@ -73,6 +74,10 @@ export function startServer(connection: Connection, factory: IStorageFactory, op
 				definitionProvider: true,
 				// Add references provider capability
 				referencesProvider: true,
+				// Add rename provider capability
+				renameProvider: {
+					prepareProvider: true,
+				},
 				// Add document symbol provider capability
 				documentSymbolProvider: true,
 			},
@@ -101,13 +106,12 @@ export function startServer(connection: Connection, factory: IStorageFactory, op
 		symbolIndex = new SymbolIndex(documents, trees, symbolStorage);
 
 		features.push(new SemanticTokenFeature(documents, trees));
-		features.push(new FoldingRangeFeature(documents, trees));
 		features.push(new CompletionFeature(documents, trees, symbolIndex));
 		features.push(new SelectionRangesFeature(documents, trees));
 		features.push(new DefinitionFeature(documents, trees, symbolIndex));
-		// Add references feature
 		features.push(new ReferencesFeature(documents, trees, symbolIndex));
-		// Add document symbols feature
+		features.push(new FoldingRangeFeature(documents, trees));
+		features.push(new RenameFeature(documents, trees, symbolIndex));
 		features.push(new DocumentSymbolsFeature(documents, trees));
 
 		symbolIndex.initFiles(documents.all().map(doc => doc.uri));


### PR DESCRIPTION
- Implemented RenameFeature to provide symbol renaming capabilities
- Added support for renaming:
  * Accounts
  * Commodities
  * Tags
  * Payees
  * Narrations
- Created `position-utils.ts` to centralize symbol extraction methods
- Integrated with existing references feature for finding and updating symbol occurrences
- Added prepare rename validation to ensure only valid symbols can be renamed
- Registered rename provider capability in server startup