### PR TITLE
Align inlay hint with currency

### DIFF
--- a/packages/lsp-client/package.json
+++ b/packages/lsp-client/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Beancount language service",
 	"description": "An Beancount language service supporting features like syntax highlighting, code completion, and more.",
 	"icon": "assets/icon.png",
-	"version": "0.0.46",
+	"version": "0.0.47",
 	"publisher": "fengkx",
 	"repository": {
 		"type": "git",
@@ -218,6 +218,12 @@
 						}
 					}
 				]
+			},
+			"workbench.colorCustomizations": {
+				"editorInlayHint.background": "#00000000"
+			},
+			"[beancount]": {
+				"editor.inlayHints.maximumLength": 0
 			}
 		}
 	},

--- a/packages/lsp-server/src/common/features/inlay-hints.ts
+++ b/packages/lsp-server/src/common/features/inlay-hints.ts
@@ -123,12 +123,14 @@ export class InlayHintFeature implements Feature {
 
 						// Calculate spacing needed to align currency
 						const numberEndPosition = hintPosition.character + formattedNumber.length;
-						const spacesNeeded = currencyColumnPosition > 0 && currencyColumnPosition > numberEndPosition
-							? currencyColumnPosition - numberEndPosition
-							: 1; // At least one space between number and currency
+						const prefixSpacesNeeded =
+							currencyColumnPosition > 0 && currencyColumnPosition > numberEndPosition
+								? currencyColumnPosition - numberEndPosition - 1
+								: 0;
 
 						// Create a single hint with proper spacing
-						const hintLabel = formattedNumber + ' '.repeat(spacesNeeded) + balanceResult.currency;
+						const hintLabel = ' '.repeat(prefixSpacesNeeded) + formattedNumber + ' '
+							+ balanceResult.currency;
 
 						hints.push({
 							position: hintPosition,
@@ -158,7 +160,7 @@ export class InlayHintFeature implements Feature {
 			if (posting.amount && posting.node) {
 				const amountNode = posting.node.childForFieldName('amount');
 				if (amountNode) {
-					const currencyNode = amountNode.childForFieldName('currency');
+					const currencyNode = amountNode.namedChild(1);
 					if (currencyNode) {
 						// Get the position of the currency
 						const currencyPosition = currencyNode.startPosition.column;


### PR DESCRIPTION
<img width="340" alt="Screenshot 2025-04-06 at 3 50 47 PM" src="https://github.com/user-attachments/assets/d978c687-6fd3-4ae2-bd40-3e75d1c9238a" />

Works. We're doing this by adding spaces as prefix though, as it looks like the column is ignored in the hintPosition we passed.

Closes #15 