### PR TITLE
feat: add document formatting feature for Beancount files

### DIFF
--- a/.cursor/rules/lsp.mdc
+++ b/.cursor/rules/lsp.mdc
@@ -1,0 +1,8 @@
+---
+description: 
+globs: packages/**/*.ts
+alwaysApply: false
+---
+Use the text document from the new vscode-languageserver-textdocument package.
+DO NOT using `import { TextDocument } from 'vscode-languageserver'`
+DO `import { TextDocument } from 'vscode-languageserver-textdocument'` instead

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [x] semantic syntax highlight
 - [x] [semantic selection](https://github.com/microsoft/language-server-protocol/issues/613#issuecomment-445832563)
 - [x] auto completion
-- [ ] formating
+- [x] formatting
 - [x] inlay hints
 - [x] diagnose
 - [ ] ~~intergate with [beancount-smart-query](https://github.com/fengkx/beancount-smart-query)~~ Maybe consider another way to using LLM

--- a/packages/lsp-client/README.md
+++ b/packages/lsp-client/README.md
@@ -53,6 +53,7 @@ The extension provides several configuration options to customize its behavior:
 - `beanLsp.inlayHints.enable`: Enable or disable inlay hints showing calculated amounts for auto-balanced transactions. Default is true.
 - `beanLsp.mainCurrency`: Main currency for price conversions. If empty, the most frequently used currency will be automatically determined.
 - `beanLsp.currencys`: List of currencies that should participate in price conversions. Commodities not included in this list (like stocks) will be excluded from conversion calculations. If empty, all commodities will be considered for conversions.
+- `beanLsp.formatter.enabled`: Enable or disable automatic formatting of Beancount files. The formatter aligns accounts, amounts (with decimal point alignment), currencies, and comments for improved readability. Default is true.
 
 ### Example Configuration
 
@@ -64,6 +65,7 @@ The extension provides several configuration options to customize its behavior:
 	"beancount.diagnostics.warnOnIncompleteTransaction": true,
 	"beanLsp.mainCurrency": "USD",
 	"beanLsp.currencys": ["USD", "EUR", "GBP", "JPY"],
+	"beanLsp.formatter.enabled": true,
 	"editor.semanticTokenColorCustomizations": {
 		"enabled": true,
 		"rules": {

--- a/packages/lsp-client/package.json
+++ b/packages/lsp-client/package.json
@@ -105,6 +105,11 @@
 					},
 					"default": [],
 					"description": "List of currencies that should participate in price conversions. Commodities not included in this list (like stocks) will be excluded from conversion calculations. If empty, all commodities will be considered for conversions."
+				},
+				"beanLsp.formatter.enabled": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable or disable automatic formatting of Beancount files. The formatter aligns accounts, amounts (with decimal point alignment), currencies, and comments for improved readability."
 				}
 			}
 		},

--- a/packages/lsp-server/src/common/features/formatter.ts
+++ b/packages/lsp-server/src/common/features/formatter.ts
@@ -1,0 +1,477 @@
+// Import necessary modules
+import { Logger } from '@bean-lsp/shared';
+import { Connection, DocumentFormattingParams, Range, TextEdit } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import Parser from 'web-tree-sitter';
+import { DocumentStore } from '../document-store';
+import { Trees } from '../trees';
+import { Feature } from './types';
+
+// Constants for formatting
+const ACCOUNT_MIN_COLUMN = 40; // Minimum column for account alignment
+const AMOUNT_MIN_COLUMN = 52; // Minimum column for amount alignment
+const CURRENCY_MIN_COLUMN = 64; // Minimum column for currency alignment
+const COMMENT_MIN_COLUMN = 76; // Minimum column for comment alignment
+
+export class FormatterFeature implements Feature {
+	// Formatter configuration
+	private formatterEnabled = true;
+	private readonly logger = new Logger('Formatter');
+
+	constructor(
+		private readonly documents: DocumentStore,
+		private readonly trees: Trees,
+	) {}
+
+	register(connection: Connection): void {
+		// Register for document formatting if enabled
+		connection.onDocumentFormatting(async (params: DocumentFormattingParams) => {
+			// Check if formatter is enabled
+			if (!this.formatterEnabled) {
+				return [];
+			}
+
+			try {
+				const document = await this.documents.retrieve(params.textDocument.uri);
+				const edits = await this.formatBeancountDocument(document);
+				// Workaround, reusing trees after formatting will get a wrong tree
+				this.trees.invalidateCache(params.textDocument.uri);
+				return edits;
+			} catch (error) {
+				this.logger.error('Error retrieving document for formatting:', error);
+				return [];
+			}
+		});
+
+		this.updateFormatterConfig(connection);
+	}
+
+	/**
+	 * Update formatter configuration from server settings
+	 */
+	private async updateFormatterConfig(connection: Connection): Promise<void> {
+		try {
+			const config = await connection.workspace.getConfiguration({ section: 'beanLsp' });
+			if (config.formatter !== undefined) {
+				const formatterEnabled = config.formatter?.enabled !== false; // Default to true if not specified
+				this.setFormatterEnabled(formatterEnabled);
+				this.logger.info(`Formatter ${formatterEnabled ? 'enabled' : 'disabled'}`);
+			}
+		} catch (error) {
+			this.logger.error('Error updating formatter configuration:', error);
+		}
+	}
+
+	/**
+	 * Enable or disable the formatter
+	 * @param enabled Whether the formatter should be enabled
+	 */
+	private setFormatterEnabled(enabled: boolean): void {
+		this.formatterEnabled = enabled;
+	}
+
+	/**
+	 * Format a Beancount document
+	 */
+	async formatBeancountDocument(document: TextDocument): Promise<TextEdit[]> {
+		const edits: TextEdit[] = [];
+
+		// Retrieve the parse tree using Trees
+		const tree = await this.trees.getParseTree(document);
+		if (!tree) {
+			this.logger.error('Failed to parse document');
+			return edits;
+		}
+
+		// Format the document by processing each transaction separately
+		this.formatTransactions(document, tree, edits);
+
+		// Format other directives (open, close, etc.)
+		this.formatDirectives(document, tree, edits);
+
+		return edits;
+	}
+
+	/**
+	 * Format transactions in the document
+	 */
+	private formatTransactions(document: TextDocument, tree: Parser.Tree, edits: TextEdit[]): void {
+		// Query to find all transactions
+		const transactionQuery = tree.rootNode.descendantsOfType('transaction');
+
+		for (const txnNode of transactionQuery) {
+			// Find all postings within this transaction
+			const postings = txnNode.descendantsOfType('posting');
+
+			// Skip if there are no postings to format
+			if (postings.length === 0) continue;
+
+			// Determine the positions for alignment
+			const positions = this.calculateAlignmentPositions(document, postings);
+
+			// Apply formatting to each posting
+			for (const posting of postings) {
+				this.formatPosting(document, posting, positions, edits);
+			}
+		}
+	}
+
+	/**
+	 * Format other directives like open, close, balance, etc.
+	 */
+	private formatDirectives(document: TextDocument, tree: Parser.Tree, edits: TextEdit[]): void {
+		// Format open/close directives
+		const openCloseQuery = tree.rootNode.descendantsOfType(['open', 'close']);
+
+		for (const directive of openCloseQuery) {
+			const account = directive.childForFieldName('account');
+			const currencies = directive.childForFieldName('currencies');
+			const comment = directive.childForFieldName('comment');
+
+			if (account && currencies) {
+				// Align currencies after account
+				const accountText = document.getText(this.rangeFromNode(document, account));
+				const currenciesStart = document.positionAt(currencies.startIndex);
+				const currenciesEnd = document.positionAt(currencies.endIndex);
+
+				// Calculate ideal position for currencies (after account)
+				const accountStartPos = document.positionAt(account.startIndex);
+				const ideal = Math.max(
+					accountStartPos.character + this.calculateStringWidth(accountText) + 3,
+					CURRENCY_MIN_COLUMN,
+				);
+
+				// Create whitespace before currencies
+				const whitespace = ' '.repeat(ideal - currenciesStart.character);
+
+				// Replace existing whitespace
+				if (currenciesStart.character !== ideal) {
+					edits.push(TextEdit.replace({
+						start: document.positionAt(account.endIndex),
+						end: currenciesStart,
+					}, whitespace));
+				}
+			}
+		}
+	}
+
+	/**
+	 * Calculate alignment positions for a set of postings
+	 */
+	private calculateAlignmentPositions(document: TextDocument, postings: Parser.SyntaxNode[]): {
+		accountColumn: number;
+		amountColumn: number;
+		currencyColumn: number;
+		commentColumn: number;
+		maxIntegerWidth: number;
+		decimalPointColumn: number;
+	} {
+		let maxAccountWidth = 0;
+		let maxAmountWidth = 0;
+		let maxIntegerWidth = 0;
+		let maxDecimalWidth = 0;
+		let maxAccountStartColumn = 0;
+		let maxCurrencyWidth = 0;
+
+		// First pass: find maximum widths
+		for (const posting of postings) {
+			const account = posting.childForFieldName('account');
+			const amount = posting.childForFieldName('amount');
+			const currency = posting.childForFieldName('currency');
+			const indentText = document.getText({
+				start: document.positionAt(posting.startIndex),
+				end: document.positionAt(account ? account.startIndex : posting.endIndex),
+			});
+
+			// Calculate starting column of account
+			const accountStartCol = this.calculateStringWidth(indentText);
+			maxAccountStartColumn = Math.max(maxAccountStartColumn, accountStartCol);
+
+			if (account) {
+				const accountText = document.getText(this.rangeFromNode(document, account));
+				maxAccountWidth = Math.max(maxAccountWidth, this.calculateStringWidth(accountText));
+			}
+
+			if (amount) {
+				const amountText = document.getText(this.rangeFromNode(document, amount));
+				maxAmountWidth = Math.max(maxAmountWidth, this.calculateStringWidth(amountText));
+
+				// Analyze integer and decimal parts of the amount
+				const parts = amountText.split('.');
+				const integerPart = parts[0]?.trim() || '';
+				const integerWidth = this.calculateStringWidth(integerPart);
+				maxIntegerWidth = Math.max(maxIntegerWidth, integerWidth);
+
+				// If there's a decimal part, calculate its width
+				if (parts.length > 1) {
+					const decimalPart = parts[1]?.trim() || '';
+					const decimalWidth = this.calculateStringWidth(decimalPart);
+					maxDecimalWidth = Math.max(maxDecimalWidth, decimalWidth);
+				}
+			}
+
+			// Calculate currency width
+			if (currency) {
+				const currencyText = document.getText(this.rangeFromNode(document, currency));
+				maxCurrencyWidth = Math.max(maxCurrencyWidth, this.calculateStringWidth(currencyText));
+			} else {
+				// Try to find currency code from the text
+				const text = document.getText(this.rangeFromNode(document, posting));
+				const currencyMatch = text.match(/[A-Z][A-Z0-9_'.-]{0,22}[A-Z0-9]/);
+				if (currencyMatch) {
+					maxCurrencyWidth = Math.max(maxCurrencyWidth, this.calculateStringWidth(currencyMatch[0]));
+				}
+			}
+		}
+
+		// Calculate columns for alignment
+		const accountColumn = Math.max(maxAccountStartColumn, 2); // Minimum 2 spaces indent
+		const amountColumn = Math.max(accountColumn + maxAccountWidth + 3, AMOUNT_MIN_COLUMN);
+		const decimalPointColumn = amountColumn + maxIntegerWidth; // Decimal point position
+		const currencyColumn = decimalPointColumn + maxDecimalWidth + 1;
+		const commentColumn = Math.max(currencyColumn + maxCurrencyWidth + 2, COMMENT_MIN_COLUMN);
+
+		return {
+			accountColumn,
+			amountColumn,
+			currencyColumn,
+			commentColumn,
+			maxIntegerWidth,
+			decimalPointColumn,
+		};
+	}
+
+	/**
+	 * Format a single posting within a transaction
+	 */
+	private formatPosting(
+		document: TextDocument,
+		posting: Parser.SyntaxNode,
+		positions: {
+			accountColumn: number;
+			amountColumn: number;
+			currencyColumn: number;
+			commentColumn: number;
+			maxIntegerWidth: number;
+			decimalPointColumn: number;
+		},
+		edits: TextEdit[],
+	): void {
+		// Get child nodes that need alignment
+		const account = posting.childForFieldName('account');
+		const amount = posting.childForFieldName('amount');
+		const optflag = posting.childForFieldName('optflag');
+		const comment = posting.childForFieldName('comment');
+		const costSpec = posting.childForFieldName('cost_spec');
+		const priceAnnotation = posting.childForFieldName('price_annotation');
+
+		if (!account) return; // Skip if no account (shouldn't happen in valid syntax)
+
+		// Line starting position (for indent)
+		const lineStartPos = document.positionAt(posting.startIndex);
+
+		// Format the indentation + optflag + account portion
+		const accountStartPos = document.positionAt(account.startIndex);
+		const accountEndPos = document.positionAt(account.endIndex);
+
+		// Fix indentation if needed (should be positions.accountColumn spaces)
+		const currentIndent = accountStartPos.character;
+		if (currentIndent !== positions.accountColumn) {
+			// For the first part, we want to ensure proper indentation
+			const idealIndent = ' '.repeat(positions.accountColumn);
+
+			// Handle flag if present
+			let indentRange;
+			if (optflag) {
+				indentRange = {
+					start: lineStartPos,
+					end: document.positionAt(optflag.startIndex),
+				};
+			} else {
+				indentRange = {
+					start: lineStartPos,
+					end: accountStartPos,
+				};
+			}
+
+			edits.push(TextEdit.replace(indentRange, idealIndent));
+		}
+
+		// Format the amount portion
+		if (amount) {
+			const amountStartPos = document.positionAt(amount.startIndex);
+			const amountEndPos = document.positionAt(amount.endIndex);
+			const amountText = document.getText({ start: amountStartPos, end: amountEndPos });
+
+			// The space between account and amount
+			const spaceRange = {
+				start: accountEndPos,
+				end: amountStartPos,
+			};
+
+			// Implement decimal point alignment
+			const parts = amountText.split('.');
+			const integerPart = parts[0]?.trim() || '';
+			const integerWidth = this.calculateStringWidth(integerPart);
+
+			// Calculate required spaces
+			let whitespaceLength;
+			// If there's a decimal point, align to the decimal point position
+			if (parts.length > 1) {
+				const spaceNeeded = positions.decimalPointColumn - accountEndPos.character - integerWidth;
+				whitespaceLength = Math.max(1, spaceNeeded);
+			} else {
+				// For cases without decimal point (integers, currency symbols, etc.)
+				whitespaceLength = Math.max(1, positions.amountColumn - accountEndPos.character);
+			}
+
+			const whitespace = ' '.repeat(whitespaceLength);
+			edits.push(TextEdit.replace(spaceRange, whitespace));
+
+			// If we have cost_spec and/or price_annotation, align them too
+			let lastEndPos = amountEndPos;
+
+			if (costSpec) {
+				const costStartPos = document.positionAt(costSpec.startIndex);
+				// Need at least one space between amount and cost
+				if (costStartPos.character - lastEndPos.character !== 1) {
+					edits.push(TextEdit.replace({
+						start: lastEndPos,
+						end: costStartPos,
+					}, ' '));
+				}
+				lastEndPos = document.positionAt(costSpec.endIndex);
+			}
+
+			if (priceAnnotation) {
+				const priceStartPos = document.positionAt(priceAnnotation.startIndex);
+
+				// Find price operator (@ or @@) which should be before priceAnnotation
+				// The operator might appear as a separate node or be part of previous text
+				let priceOpText = '';
+				let priceOperatorPos = {
+					start: lastEndPos,
+					end: priceStartPos,
+				};
+
+				// Get text between last element and price annotation
+				const betweenText = document.getText(priceOperatorPos);
+
+				// Check for @ or @@ in the text
+				const atMatch = betweenText.match(/@{1,2}/);
+				if (atMatch) {
+					// Ensure proper spacing around @ or @@
+					const isDoubleAt = atMatch[0] === '@@';
+					const operator = isDoubleAt ? '@@' : '@';
+
+					// We want one space before and one space after the operator
+					// Replace the entire range with properly spaced operator
+					const properlySpaced = ' ' + operator + ' ';
+					edits.push(TextEdit.replace(priceOperatorPos, properlySpaced));
+				} else {
+					// No @ found, this is unusual but handle it by adding a default @ with spacing
+					this.logger.warn('Price annotation found but no @ or @@ operator detected in text:', betweenText);
+					edits.push(TextEdit.replace(priceOperatorPos, ' @ '));
+				}
+			}
+
+			// Check if there's a currency symbol directly after the amount
+			const restOfLine = document.getText({
+				start: amountEndPos,
+				end: document.positionAt(posting.endIndex),
+			});
+
+			// Check for currency symbols that follow the amount
+			const currencyMatch = restOfLine.match(/\s+([A-Z][A-Z0-9_'.-]{0,22}[A-Z0-9])/);
+			if (currencyMatch && currencyMatch[1] && !priceAnnotation && !costSpec) {
+				// Found a currency symbol, ensure there's exactly one space
+				const currencyText = currencyMatch[1];
+				const matchIndex = restOfLine.indexOf(currencyText);
+				if (matchIndex >= 0) {
+					const currencyStart = amountEndPos.character + matchIndex;
+					const currencyStartPos = {
+						line: amountEndPos.line,
+						character: currencyStart,
+					};
+
+					// Replace whitespace between amount and currency
+					edits.push(TextEdit.replace({
+						start: amountEndPos,
+						end: currencyStartPos,
+					}, ' '));
+				}
+			}
+		} else {
+			// No amount, but need to align trailing elements if any
+			let lastEndPos = accountEndPos;
+			if (costSpec) {
+				const costStartPos = document.positionAt(costSpec.startIndex);
+				edits.push(TextEdit.replace({
+					start: lastEndPos,
+					end: costStartPos,
+				}, ' '.repeat(positions.amountColumn - accountEndPos.character)));
+				lastEndPos = document.positionAt(costSpec.endIndex);
+			}
+		}
+
+		// Finally, format comments if present and if there's no existing alignment
+		if (comment) {
+			const commentStartPos = document.positionAt(comment.startIndex);
+			const commentText = document.getText(this.rangeFromNode(document, comment));
+
+			// Find the position of the last element before the comment
+			let lastEndPos;
+			if (priceAnnotation) lastEndPos = document.positionAt(priceAnnotation.endIndex);
+			else if (costSpec) lastEndPos = document.positionAt(costSpec.endIndex);
+			else if (amount) lastEndPos = document.positionAt(amount.endIndex);
+			else lastEndPos = accountEndPos;
+
+			// Align comment (if it's not already aligned properly)
+			if (
+				commentStartPos.character < positions.commentColumn
+				&& commentStartPos.character - lastEndPos.character !== 1
+			) {
+				edits.push(TextEdit.replace({
+					start: lastEndPos,
+					end: commentStartPos,
+				}, ' '.repeat(Math.max(1, positions.commentColumn - lastEndPos.character))));
+			}
+		}
+	}
+
+	/**
+	 * Helper to convert a tree-sitter node to a VS Code Range
+	 */
+	private rangeFromNode(document: TextDocument, node: Parser.SyntaxNode): Range {
+		return {
+			start: document.positionAt(node.startIndex),
+			end: document.positionAt(node.endIndex),
+		};
+	}
+
+	/**
+	 * Calculate the visual width of a string, considering double-width characters
+	 * like CJK characters.
+	 */
+	private calculateStringWidth(text: string): number {
+		let width = 0;
+		for (const char of text) {
+			// Use a more comprehensive check for wide characters
+			// This includes CJK Unified Ideographs, Hiragana, Katakana, Hangul, etc.
+			if (
+				(char >= '\u4e00' && char <= '\u9fff') // CJK Unified Ideographs
+				|| (char >= '\u3040' && char <= '\u309f') // Hiragana
+				|| (char >= '\u30a0' && char <= '\u30ff') // Katakana
+				|| (char >= '\u3400' && char <= '\u4dbf') // CJK Extension A
+				|| (char >= '\uf900' && char <= '\ufaff') // CJK Compatibility Ideographs
+				|| (char >= '\uac00' && char <= '\ud7af') // Hangul Syllables
+				|| (char >= '\u3000' && char <= '\u303f') // CJK Symbols and Punctuation
+			) {
+				width += 2;
+			} else {
+				width += 1;
+			}
+		}
+		return width;
+	}
+}

--- a/packages/lsp-server/src/common/startServer.ts
+++ b/packages/lsp-server/src/common/startServer.ts
@@ -14,6 +14,7 @@ import { DiagnosticsFeature } from './features/diagnostics';
 import { DocumentLinksFeature } from './features/document-links';
 import { DocumentSymbolsFeature } from './features/document-symbols';
 import { FoldingRangeFeature } from './features/folding-ranges';
+import { FormatterFeature } from './features/formatter';
 import { HoverFeature } from './features/hover';
 import { InlayHintFeature } from './features/inlay-hints';
 import { PriceMap } from './features/prices-index/price-map';
@@ -102,6 +103,8 @@ export function startServer(
 				inlayHintProvider: {
 					resolveProvider: false, // We don't need to resolve hints further
 				},
+				// Add document formatting capability
+				documentFormattingProvider: true,
 			},
 		};
 		if (params.capabilities.workspace?.configuration) {
@@ -140,13 +143,13 @@ export function startServer(
 		features.push(new DocumentSymbolsFeature(documents, trees));
 		features.push(new DiagnosticsFeature(documents, trees, optionsManager));
 		features.push(new DocumentLinksFeature(documents, trees));
-		features.push(new InlayHintFeature(documents, trees));
+		features.push(new FormatterFeature(documents, trees));
 
 		if (typeof beanMgrFactory === 'function') {
 			beanMgr = beanMgrFactory(connection, params.initializationOptions?.extensionUri);
 		}
 		features.push(new HoverFeature(documents, trees, priceMap, symbolIndex, beanMgr));
-
+		features.push(new InlayHintFeature(documents, trees));
 		// Initialize all features
 		symbolIndex.initFiles(documents.all().map(doc => doc.uri));
 
@@ -212,7 +215,7 @@ export function startServer(
 				);
 			}
 
-			// 应用主要货币设置
+			// Apply main currency setting
 			if (config.mainCurrency) {
 				const featureWithPriceMap = features.find(f => f instanceof HoverFeature) as HoverFeature;
 				if (featureWithPriceMap) {
@@ -221,7 +224,7 @@ export function startServer(
 				}
 			}
 
-			// 设置允许的货币列表
+			// Set allowed currencies list
 			if (config.currencys !== undefined) {
 				const featureWithPriceMap = features.find(f => f instanceof HoverFeature) as HoverFeature;
 				if (featureWithPriceMap) {
@@ -248,7 +251,7 @@ export function startServer(
 						);
 					}
 
-					// 更新主要货币设置
+					// Update main currency setting
 					if (config.mainCurrency !== undefined) {
 						const featureWithPriceMap = features.find(f => f instanceof HoverFeature) as HoverFeature;
 						if (featureWithPriceMap) {
@@ -257,7 +260,7 @@ export function startServer(
 						}
 					}
 
-					// 更新允许的货币列表
+					// Update allowed currencies list
 					if (config.currencys !== undefined) {
 						const featureWithPriceMap = features.find(f => f instanceof HoverFeature) as HoverFeature;
 						if (featureWithPriceMap) {

--- a/packages/lsp-server/src/common/trees.ts
+++ b/packages/lsp-server/src/common/trees.ts
@@ -30,6 +30,11 @@ export class Trees {
 		}));
 		this._webTreeSitterWasmPath = webTreeSitterWasmPath;
 	}
+
+	public invalidateCache(uri: string) {
+		this._cache.delete(uri);
+	}
+
 	private static async getParserInstance(webTreeSitterWasmPath?: string) {
 		const parser = await getParser(webTreeSitterWasmPath);
 		return parser;


### PR DESCRIPTION
- Implemented a new FormatterFeature to enable automatic formatting of Beancount files, aligning accounts, amounts, currencies, and comments for improved readability.
- Updated package.json to include a configuration option for enabling/disabling the formatter.
- Enhanced README documentation to reflect the new formatting capabilities and configuration options.
- Added a new lsp.mdc file to specify rules for the language server protocol.