### PR TITLE
Formatting fixes

### DIFF
--- a/packages/lsp-server/src/common/features/formatter.ts
+++ b/packages/lsp-server/src/common/features/formatter.ts
@@ -13,6 +13,7 @@ const ACCOUNT_MIN_COLUMN = 40; // Minimum column for account alignment
 const AMOUNT_MIN_COLUMN = 52; // Minimum column for amount alignment
 const CURRENCY_MIN_COLUMN = 64; // Minimum column for currency alignment
 const COMMENT_MIN_COLUMN = 76; // Minimum column for comment alignment
+const CURRENCY_MIN_SPACING = 3; // Minimum spacing between account and currency for directives
 
 export class FormatterFeature implements Feature {
 	// Formatter configuration
@@ -140,13 +141,14 @@ export class FormatterFeature implements Feature {
 
 				// Calculate ideal position for currencies (after account)
 				const accountStartPos = document.positionAt(account.startIndex);
+				const accountVisualEndPos = accountStartPos.character + this.calculateStringWidth(accountText);
 				const ideal = Math.max(
-					accountStartPos.character + this.calculateStringWidth(accountText) + 3,
+					accountVisualEndPos + CURRENCY_MIN_SPACING,
 					CURRENCY_MIN_COLUMN,
 				);
 
-				// Create whitespace before currencies
-				const whitespace = ' '.repeat(ideal - currenciesStart.character);
+				// Create whitespace between account and currencies
+				const whitespace = ' '.repeat(ideal - accountVisualEndPos);
 
 				// Replace existing whitespace
 				if (currenciesStart.character !== ideal) {

--- a/packages/lsp-server/src/common/features/formatter.ts
+++ b/packages/lsp-server/src/common/features/formatter.ts
@@ -382,8 +382,12 @@ export class FormatterFeature implements Feature {
 			}
 
 			// Check if there's a currency symbol directly after the amount
+			const amountWithoutCurrency = amount.namedChild(0);
+			const amountWithoutCurrencyEndPos = amountWithoutCurrency
+				? document.positionAt(amountWithoutCurrency.endIndex)
+				: amountEndPos;
 			const restOfLine = document.getText({
-				start: amountEndPos,
+				start: amountWithoutCurrencyEndPos,
 				end: document.positionAt(posting.endIndex),
 			});
 
@@ -394,15 +398,15 @@ export class FormatterFeature implements Feature {
 				const currencyText = currencyMatch[1];
 				const matchIndex = restOfLine.indexOf(currencyText);
 				if (matchIndex >= 0) {
-					const currencyStart = amountEndPos.character + matchIndex;
+					const currencyStart = amountWithoutCurrencyEndPos.character + matchIndex;
 					const currencyStartPos = {
-						line: amountEndPos.line,
+						line: amountWithoutCurrencyEndPos.line,
 						character: currencyStart,
 					};
 
 					// Replace whitespace between amount and currency
 					edits.push(TextEdit.replace({
-						start: amountEndPos,
+						start: amountWithoutCurrencyEndPos,
 						end: currencyStartPos,
 					}, ' '));
 				}


### PR DESCRIPTION
Fixes two bugs
- For formatting directives, use account end pos instead of currency start pos. The current behavior of using the existing currency start pos results in exceptions if the current file has the start pos after the ideal pos
- For formatting transactions, actually align currencies. It is currently looking for a currency after the amount node, but the currency is actually inside the amount node. 

Tested this by running the formatter on all my files. 