### PR TITLE
Check pending transaction before checking balance

### DIFF
--- a/packages/lsp-server/src/common/features/diagnostics.ts
+++ b/packages/lsp-server/src/common/features/diagnostics.ts
@@ -129,11 +129,6 @@ export class DiagnosticsFeature implements Feature {
 			const chunk = transactions.slice(i, i + CHUNK_SIZE);
 
 			for (const transaction of chunk) {
-				// Skip transactions with only one posting having no amount
-				// (Beancount will auto-compute this)
-				if (hasOnlyOneIncompleteAmount(transaction.postings)) {
-					continue;
-				}
 				// Check for pending transactions (marked with '!')
 				if (transaction.flag === '!' && this.config.warnOnIncompleteTransaction) {
 					diagnostics.push({
@@ -142,6 +137,12 @@ export class DiagnosticsFeature implements Feature {
 						message: `transaction flagged with "!": ${document.getText(transaction.headerRange)}`,
 						source: 'beancount-lsp',
 					});
+				}
+
+				// Skip transactions with only one posting having no amount
+				// (Beancount will auto-compute this)
+				if (hasOnlyOneIncompleteAmount(transaction.postings)) {
+					continue;
 				}
 
 				// Check for both cost and price on the same posting (which is not allowed)


### PR DESCRIPTION
Diagnostics was ignoring some pending transactions because it had an incomplete posting