### PR TITLE
Include subaccount balances when hovering

### DIFF
--- a/packages/lsp-client/README.md
+++ b/packages/lsp-client/README.md
@@ -54,6 +54,7 @@ The extension provides several configuration options to customize its behavior:
 - `beanLsp.mainCurrency`: Main currency for price conversions. If empty, the most frequently used currency will be automatically determined.
 - `beanLsp.currencys`: List of currencies that should participate in price conversions. Commodities not included in this list (like stocks) will be excluded from conversion calculations. If empty, all commodities will be considered for conversions.
 - `beanLsp.formatter.enabled`: Enable or disable automatic formatting of Beancount files. The formatter aligns accounts, amounts (with decimal point alignment), currencies, and comments for improved readability. Default is true.
+- `beanLsp.hover.includeSubaccountBalance`: Enable or disable the hover window including balances of subaccounts. By default, only show the balance of the hovered account. Default is false.
 
 ### Example Configuration
 
@@ -66,6 +67,7 @@ The extension provides several configuration options to customize its behavior:
 	"beanLsp.mainCurrency": "USD",
 	"beanLsp.currencys": ["USD", "EUR", "GBP", "JPY"],
 	"beanLsp.formatter.enabled": true,
+	"beanLsp.hover.includeSubaccountBalance": false,
 	"editor.semanticTokenColorCustomizations": {
 		"enabled": true,
 		"rules": {

--- a/packages/lsp-client/package.json
+++ b/packages/lsp-client/package.json
@@ -110,6 +110,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enable or disable automatic formatting of Beancount files. The formatter aligns accounts, amounts (with decimal point alignment), currencies, and comments for improved readability."
+				},
+				"beanLsp.hover.includeSubaccountBalance": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enable or disable the hover window including balances of subaccounts. By default, only show the balance of the hovered account."
 				}
 			}
 		},

--- a/packages/lsp-server/src/common/features/types.ts
+++ b/packages/lsp-server/src/common/features/types.ts
@@ -4,11 +4,17 @@ export interface Feature {
 	register(connection: Connection): unknown;
 }
 
+export interface Amount {
+	number: string;
+	currency: string;
+}
+
 /**
  * Get information from the REAL beancount executable. Only available in the node extension.
  */
 export interface RealBeancountManager {
-	getBalance(account: string): Promise<string[]>;
+	getBalance(account: string, includeSubaccountBalance: boolean): Amount[];
+	getSubaccountBalances(account: string): Map<string, Amount[]>;
 	setMainFile(mainFile: string): Promise<void>;
 }
 


### PR DESCRIPTION
If there are subaccounts:
<img width="307" alt="Screenshot 2025-04-12 at 10 34 22 PM" src="https://github.com/user-attachments/assets/11757511-a4ae-4186-a7c1-93b08922e5c1" />


If there are no subaccounts:
<img width="465" alt="Screenshot 2025-04-12 at 10 33 59 PM" src="https://github.com/user-attachments/assets/c3cf8219-abed-4599-8fa2-567dd14654fd" />

I also reduced the padding so there's less whitespace between the number and the currency.