### PR TITLE
Include errors and flagged transactions from beancount in diagnostics

### DIFF
--- a/packages/lsp-server/src/common/features/types.ts
+++ b/packages/lsp-server/src/common/features/types.ts
@@ -9,12 +9,27 @@ export interface Amount {
 	currency: string;
 }
 
+export interface BeancountError {
+	file: string;
+	line: number;
+	message: string;
+}
+
+export interface BeancountFlag {
+	file: string;
+	line: number;
+	message: string;
+	flag: string;
+}
+
 /**
  * Get information from the REAL beancount executable. Only available in the node extension.
  */
 export interface RealBeancountManager {
 	getBalance(account: string, includeSubaccountBalance: boolean): Amount[];
 	getSubaccountBalances(account: string): Map<string, Amount[]>;
+	getErrors(): BeancountError[];
+	getFlagged(): BeancountFlag[];
 	setMainFile(mainFile: string): Promise<void>;
 }
 

--- a/packages/lsp-server/src/common/startServer.ts
+++ b/packages/lsp-server/src/common/startServer.ts
@@ -141,13 +141,13 @@ export function startServer(
 		features.push(new FoldingRangeFeature(documents, trees));
 		features.push(new RenameFeature(documents, trees, symbolIndex));
 		features.push(new DocumentSymbolsFeature(documents, trees));
-		features.push(new DiagnosticsFeature(documents, trees, optionsManager));
 		features.push(new DocumentLinksFeature(documents, trees));
 		features.push(new FormatterFeature(documents, trees));
 
 		if (typeof beanMgrFactory === 'function') {
 			beanMgr = beanMgrFactory(connection, params.initializationOptions?.extensionUri);
 		}
+		features.push(new DiagnosticsFeature(documents, trees, optionsManager, beanMgr));
 		features.push(new HoverFeature(documents, trees, priceMap, symbolIndex, beanMgr));
 		features.push(new InlayHintFeature(documents, trees));
 		// Initialize all features

--- a/packages/lsp-server/src/common/utils/event-bus.ts
+++ b/packages/lsp-server/src/common/utils/event-bus.ts
@@ -134,4 +134,5 @@ export const globalEventBus = new EventBus<GlobalEvents>();
 
 export const enum GlobalEvents {
 	ConfigurationChanged = 'configuration-changed',
+	BeancountUpdate = 'beancount-update',
 }


### PR DESCRIPTION
Closes #18 

The current diagnostics only supports comparing balances for transactions and raising warnings for flagged transactions in currently opened files. 

When we have a bean manager, we can do more by taking the errors and flagged transactions from beancheck.

We do this, preferring the current diagnostics (as it does not require saving), and falling back to the beancount diagnostics if there were no diagnostics for the line