### PR TITLE
Try support vim

### DIFF
--- a/packages/lsp-client/CHANGELOG.md
+++ b/packages/lsp-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.62
+
+- chore: bump lsp-client version to 0.0.62 ([fefe775](https://github.com/fengkx/beancount-lsp/commit/fefe775))
+- fix: correct configuration property name in DocumentStore ([ef05566](https://github.com/fengkx/beancount-lsp/commit/ef05566))
+- chore: update dependencies in package.json files ([ea57ffe](https://github.com/fengkx/beancount-lsp/commit/ea57ffe))
+
 ## v0.0.60
 
 - chore: bump lsp-client version to 0.0.60 ([7fb03fe](https://github.com/fengkx/beancount-lsp/commit/7fb03fe))

--- a/packages/lsp-client/README.md
+++ b/packages/lsp-client/README.md
@@ -47,7 +47,7 @@ The extension provides several configuration options to customize its behavior:
   - `messages`: Shows info-level messages, warnings, and errors (default)
   - `debug`: Shows debug-level messages and below
   - `verbose`: Shows all log messages (most verbose)
-- `beanLsp.manBeanFile`: Specifies the main Beancount file to use for analysis. This should be relative to the workspace root. Default is "main.bean".
+- `beanLsp.mainBeanFile`: Specifies the main Beancount file to use for analysis. This should be relative to the workspace root. Default is "main.bean".
 - `beancount.diagnostics.tolerance`: Tolerance value for transaction balancing. Set to 0 for exact matching. Default is 0.005.
 - `beancount.diagnostics.warnOnIncompleteTransaction`: Show warnings for incomplete transactions (marked with '!' flag). These are transactions that are considered unconfirmed in Beancount. Default is true.
 - `beanLsp.inlayHints.enable`: Enable or disable inlay hints showing calculated amounts for auto-balanced transactions. Default is true.
@@ -60,7 +60,7 @@ The extension provides several configuration options to customize its behavior:
 
 ```json
 {
-	"beanLsp.manBeanFile": "main.bean",
+	"beanLsp.mainBeanFile": "main.bean",
 	"beanLsp.trace.server": "debug",
 	"beancount.diagnostics.tolerance": 0.005,
 	"beancount.diagnostics.warnOnIncompleteTransaction": true,

--- a/packages/lsp-client/package.json
+++ b/packages/lsp-client/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Beancount language service",
 	"description": "An Beancount language service supporting features like syntax highlighting, code completion, and more.",
 	"icon": "assets/icon.png",
-	"version": "0.0.60",
+	"version": "0.0.62",
 	"publisher": "fengkx",
 	"private": true,
 	"repository": {

--- a/packages/lsp-client/package.json
+++ b/packages/lsp-client/package.json
@@ -75,7 +75,7 @@
 					"default": "messages",
 					"description": "Controls the verbosity of logging and traces the communication between VS Code and the language server. Values from least to most verbose: off (errors only), error, warn, messages (info), debug, verbose (trace)."
 				},
-				"beanLsp.manBeanFile": {
+				"beanLsp.mainBeanFile": {
 					"scope": "resource",
 					"type": "string",
 					"default": "main.bean",

--- a/packages/lsp-client/src/browser/extension.ts
+++ b/packages/lsp-client/src/browser/extension.ts
@@ -32,11 +32,6 @@ export function activate(context: vscode.ExtensionContext): void {
 	statusBarItem.show();
 	context.subscriptions.push(statusBarItem);
 
-	// Show notification that this is experimental
-	vscode.window.showInformationMessage(
-		'Beancount LSP browser extension is experimental and might have limited functionality compared to the desktop version.',
-	);
-
 	try {
 		// Resolve the web-tree-sitter.wasm path
 		const webTreeSitterWasmPath = resolveWebTreeSitterWasmPath(context);

--- a/packages/lsp-client/src/common/client.ts
+++ b/packages/lsp-client/src/common/client.ts
@@ -1,7 +1,7 @@
 import { CustomMessages, Logger, logLevelToString, mapTraceServerToLogLevel } from '@bean-lsp/shared';
 import * as vscode from 'vscode';
 // Import from base package for shared types between node and browser
-import type { InitializeParams, LanguageClientOptions, ProtocolConnection } from 'vscode-languageclient';
+import type { LanguageClientOptions } from 'vscode-languageclient';
 import { State } from 'vscode-languageclient';
 import { Utils as UriUtils } from 'vscode-uri';
 import { tools } from './llm/tools';
@@ -196,12 +196,6 @@ export function createClientOptions(options: ClientOptions): LanguageClientOptio
 			globalStorageUri: options.globalStorageUri?.toString(),
 			extensionUri: options.extensionUri?.toString(),
 		},
-		middleware: {
-			sendRequest(type, param, token, next) {
-				console.log('===== sendRequest', type, param, token);
-				return next(type, param, token);
-			},
-		},
 	};
 }
 
@@ -230,16 +224,16 @@ export function setupStatusBar(ctx: ExtensionContext<'browser' | 'node'>): void 
  * Sets up custom message handlers for the client
  */
 export function setupCustomMessageHandlers(ctx: ExtensionContext<'browser' | 'node'>): void {
-	const originalInitialize = ctx.client['doInitialize'].bind(ctx.client);
-	ctx.client['doInitialize'] = async (connection: ProtocolConnection, params: InitializeParams) => {
-		console.log('===== doInitialize', params);
-		// @ts-expect-error customMessage is not part of the protocol
-		params.capabilities['customMessage'] = {
-			[CustomMessages.ListBeanFile]: true,
-			[CustomMessages.FileRead]: true,
-		};
-		return originalInitialize(connection, params);
-	};
+	// const originalInitialize = ctx.client['doInitialize'].bind(ctx.client);
+	// ctx.client['doInitialize'] = async (connection: ProtocolConnection, params: InitializeParams) => {
+	// 	console.log('===== doInitialize', params);
+	// 	// @ts-expect-error customMessage is not part of the protocol
+	// 	params.capabilities['customMessage'] = {
+	// 		[CustomMessages.ListBeanFile]: true,
+	// 		[CustomMessages.FileRead]: true,
+	// 	};
+	// 	return originalInitialize(connection, params);
+	// };
 
 	ctx.client.onRequest(CustomMessages.ListBeanFile, async () => {
 		const exclude = await generateExcludePattern();

--- a/packages/lsp-client/src/common/client.ts
+++ b/packages/lsp-client/src/common/client.ts
@@ -1,7 +1,8 @@
 import { CustomMessages, Logger, logLevelToString, mapTraceServerToLogLevel } from '@bean-lsp/shared';
 import * as vscode from 'vscode';
 // Import from base package for shared types between node and browser
-import { LanguageClientOptions, State } from 'vscode-languageclient';
+import type { InitializeParams, LanguageClientOptions, ProtocolConnection } from 'vscode-languageclient';
+import { State } from 'vscode-languageclient';
 import { Utils as UriUtils } from 'vscode-uri';
 import { tools } from './llm/tools';
 import { ClientOptions, ExtensionContext } from './types';
@@ -195,6 +196,12 @@ export function createClientOptions(options: ClientOptions): LanguageClientOptio
 			globalStorageUri: options.globalStorageUri?.toString(),
 			extensionUri: options.extensionUri?.toString(),
 		},
+		middleware: {
+			sendRequest(type, param, token, next) {
+				console.log('===== sendRequest', type, param, token);
+				return next(type, param, token);
+			},
+		},
 	};
 }
 
@@ -223,6 +230,17 @@ export function setupStatusBar(ctx: ExtensionContext<'browser' | 'node'>): void 
  * Sets up custom message handlers for the client
  */
 export function setupCustomMessageHandlers(ctx: ExtensionContext<'browser' | 'node'>): void {
+	const originalInitialize = ctx.client['doInitialize'].bind(ctx.client);
+	ctx.client['doInitialize'] = async (connection: ProtocolConnection, params: InitializeParams) => {
+		console.log('===== doInitialize', params);
+		// @ts-expect-error customMessage is not part of the protocol
+		params.capabilities['customMessage'] = {
+			[CustomMessages.ListBeanFile]: true,
+			[CustomMessages.FileRead]: true,
+		};
+		return originalInitialize(connection, params);
+	};
+
 	ctx.client.onRequest(CustomMessages.ListBeanFile, async () => {
 		const exclude = await generateExcludePattern();
 		const files = await vscode.workspace.findFiles('**/*.{bean,beancount}', exclude);

--- a/packages/lsp-client/src/common/client.ts
+++ b/packages/lsp-client/src/common/client.ts
@@ -1,7 +1,7 @@
 import { CustomMessages, Logger, logLevelToString, mapTraceServerToLogLevel } from '@bean-lsp/shared';
 import * as vscode from 'vscode';
 // Import from base package for shared types between node and browser
-import type { LanguageClientOptions } from 'vscode-languageclient';
+import type { InitializeParams, LanguageClientOptions, ProtocolConnection } from 'vscode-languageclient';
 import { State } from 'vscode-languageclient';
 import { Utils as UriUtils } from 'vscode-uri';
 import { tools } from './llm/tools';
@@ -224,16 +224,16 @@ export function setupStatusBar(ctx: ExtensionContext<'browser' | 'node'>): void 
  * Sets up custom message handlers for the client
  */
 export function setupCustomMessageHandlers(ctx: ExtensionContext<'browser' | 'node'>): void {
-	// const originalInitialize = ctx.client['doInitialize'].bind(ctx.client);
-	// ctx.client['doInitialize'] = async (connection: ProtocolConnection, params: InitializeParams) => {
-	// 	console.log('===== doInitialize', params);
-	// 	// @ts-expect-error customMessage is not part of the protocol
-	// 	params.capabilities['customMessage'] = {
-	// 		[CustomMessages.ListBeanFile]: true,
-	// 		[CustomMessages.FileRead]: true,
-	// 	};
-	// 	return originalInitialize(connection, params);
-	// };
+	const originalInitialize = ctx.client['doInitialize'].bind(ctx.client);
+	ctx.client['doInitialize'] = async (connection: ProtocolConnection, params: InitializeParams) => {
+		console.log('===== doInitialize', params);
+		// @ts-expect-error customMessage is not part of the protocol
+		params.capabilities['customMessage'] = {
+			[CustomMessages.ListBeanFile]: true,
+			[CustomMessages.FileRead]: true,
+		};
+		return originalInitialize(connection, params);
+	};
 
 	ctx.client.onRequest(CustomMessages.ListBeanFile, async () => {
 		const exclude = await generateExcludePattern();

--- a/packages/lsp-server/src/browser/server.ts
+++ b/packages/lsp-server/src/browser/server.ts
@@ -5,6 +5,7 @@ import {
 	ProposedFeatures,
 } from 'vscode-languageserver/browser';
 
+import { DocumentStore } from 'src/common/document-store';
 import { ServerOptions, startServer } from '../common/startServer';
 import { factory } from './storage';
 
@@ -20,8 +21,9 @@ const serverOptions: ServerOptions = {
 	isBrowser: true,
 };
 
+const documents = new DocumentStore(connection);
 // Start the server with the options
-startServer(connection, factory, undefined, serverOptions);
+startServer(connection, factory, documents, undefined, serverOptions);
 
 // Listen on the connection
 connection.listen();

--- a/packages/lsp-server/src/browser/server.ts
+++ b/packages/lsp-server/src/browser/server.ts
@@ -16,7 +16,9 @@ const messageWriter = new BrowserMessageWriter(self);
 const connection = createConnection(ProposedFeatures.all, messageReader, messageWriter);
 
 // Server options - will be populated by the initialization options in startServer
-const serverOptions: ServerOptions = {};
+const serverOptions: ServerOptions = {
+	isBrowser: true,
+};
 
 // Start the server with the options
 startServer(connection, factory, undefined, serverOptions);

--- a/packages/lsp-server/src/common/document-store.ts
+++ b/packages/lsp-server/src/common/document-store.ts
@@ -156,9 +156,9 @@ export class DocumentStore extends TextDocuments<TextDocument> {
 			return null;
 		}
 
-		if (workspace && !config.manBeanFile) {
+		if (workspace && !config.mainBeanFile) {
 			this._connection!.window.showWarningMessage(
-				`Using default 'main.bean' as manBeanFile, You should configure 'beanLsp.manBeanFile'`,
+				`Using default 'main.bean' as manBeanFile, You should configure 'beanLsp.mainBeanFile'`,
 			);
 		}
 		const rootUri = workspace[0]?.uri;
@@ -167,7 +167,7 @@ export class DocumentStore extends TextDocuments<TextDocument> {
 			return null;
 		}
 
-		const mainAbsPath = UriUtils.joinPath(URI.parse(rootUri), config.manBeanFile ?? 'main.bean');
+		const mainAbsPath = UriUtils.joinPath(URI.parse(rootUri), config.mainBeanFile ?? 'main.bean');
 
 		return mainAbsPath.toString() as string;
 	}

--- a/packages/lsp-server/src/common/features/types.ts
+++ b/packages/lsp-server/src/common/features/types.ts
@@ -35,3 +35,8 @@ export interface RealBeancountManager {
 }
 
 export type BeancountManagerFactory = (connection: Connection, extensionUri: string) => RealBeancountManager;
+
+export interface PlatformMethods {
+	findBeanFiles: () => Promise<string[]>;
+	readFile: (uri: string) => Promise<string>;
+}

--- a/packages/lsp-server/src/common/startServer.ts
+++ b/packages/lsp-server/src/common/startServer.ts
@@ -43,6 +43,8 @@ export interface IStorageFactory<T> {
 export interface ServerOptions {
 	webTreeSitterWasmPath?: string;
 	logLevel?: LogLevel;
+
+	isBrowser: boolean;
 }
 
 // Create a server logger
@@ -52,7 +54,7 @@ export function startServer(
 	connection: Connection,
 	factory: IStorageFactory<unknown>,
 	beanMgrFactory: BeancountManagerFactory | undefined,
-	options: ServerOptions = {},
+	options: ServerOptions,
 ): void {
 	// Set initial log level from options
 	if (options.logLevel !== undefined) {
@@ -130,7 +132,7 @@ export function startServer(
 		await symbolStorage.autoloadPromise;
 		connection.onExit(() => factory.destroy(symbolStorage));
 
-		documents = new DocumentStore(connection);
+		documents = new DocumentStore(connection, params, options.isBrowser);
 		const trees = new Trees(documents, options.webTreeSitterWasmPath!);
 		const optionsManager = BeancountOptionsManager.getInstance();
 		const historyContext = new HistoryContext(trees);

--- a/packages/lsp-server/src/common/startServer.ts
+++ b/packages/lsp-server/src/common/startServer.ts
@@ -53,6 +53,7 @@ const serverLogger = new Logger('Server');
 export function startServer(
 	connection: Connection,
 	factory: IStorageFactory<unknown>,
+	documents: DocumentStore,
 	beanMgrFactory: BeancountManagerFactory | undefined,
 	options: ServerOptions,
 ): void {
@@ -74,11 +75,11 @@ export function startServer(
 
 	const features: Feature[] = [];
 
-	let documents: DocumentStore;
 	let symbolIndex: SymbolIndex;
 	let beanMgr: RealBeancountManager | undefined;
 
 	connection.onInitialize(async (params: InitializeParams): Promise<InitializeResult> => {
+		documents.setInitializeParams(params);
 		const result: InitializeResult = {
 			capabilities: {
 				textDocumentSync: TextDocumentSyncKind.Incremental,
@@ -132,7 +133,6 @@ export function startServer(
 		await symbolStorage.autoloadPromise;
 		connection.onExit(() => factory.destroy(symbolStorage));
 
-		documents = new DocumentStore(connection, params, options.isBrowser);
 		const trees = new Trees(documents, options.webTreeSitterWasmPath!);
 		const optionsManager = BeancountOptionsManager.getInstance();
 		const historyContext = new HistoryContext(trees);

--- a/packages/lsp-server/src/common/startServer.ts
+++ b/packages/lsp-server/src/common/startServer.ts
@@ -206,6 +206,8 @@ export function startServer(
 		const mainBeanFile = await documents.getMainBeanFileUri();
 		serverLogger.info(`mainBeanFile ${mainBeanFile}`);
 		await documents.refetchBeanFiles();
+		await symbolIndex.initFiles(documents.beanFiles);
+		await symbolIndex.unleashFiles([]);
 
 		if (mainBeanFile) {
 			await symbolIndex.initFiles([mainBeanFile]);

--- a/packages/lsp-server/src/node/beancount-manager.ts
+++ b/packages/lsp-server/src/node/beancount-manager.ts
@@ -1,14 +1,14 @@
 import { Logger } from '@bean-lsp/shared';
 import { $, execa } from 'execa';
+import { Connection, DidSaveTextDocumentParams } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
 import {
 	Amount,
 	BeancountError,
 	BeancountFlag,
 	BeancountManagerFactory,
 	RealBeancountManager,
-} from 'src/common/features/types';
-import { Connection, DidSaveTextDocumentParams } from 'vscode-languageserver';
-import { URI } from 'vscode-uri';
+} from '../common/features/types';
 import { globalEventBus, GlobalEvents } from '../common/utils/event-bus';
 
 interface AccountDetails {

--- a/packages/lsp-server/src/node/server.ts
+++ b/packages/lsp-server/src/node/server.ts
@@ -1,8 +1,29 @@
+import { glob } from 'fast-glob';
+import { readFile } from 'fs/promises';
+import { DocumentStore } from 'src/common/document-store';
+import { pathToFileURL } from 'url';
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
-
+import { URI } from 'vscode-uri';
 import { ServerOptions, startServer } from '../common/startServer';
 import { beananagerFactory } from './beancount-manager';
 import { factory } from './storage';
+
+class DocumentStoreInNode extends DocumentStore {
+	protected override async fallbackListBeanFiles(workspaceFolder: { uri: string }): Promise<string[]> {
+		const workspacePath = URI.parse(workspaceFolder.uri).fsPath;
+		const files = await glob('**/*.{bean,beancount}', {
+			cwd: workspacePath,
+			ignore: ['.venv/**', '**/*.log', '**/*.tmp', '**/*.tmp.*', '**/*.tmp.*.*', '**/*.pyc'],
+			absolute: true,
+		});
+		return files.map((p) => pathToFileURL(p).toString());
+	}
+
+	protected override async fallbackFileRead(uri: string): Promise<ArrayBuffer> {
+		const buffer = await readFile(new URL(uri));
+		return new Uint8Array(buffer);
+	}
+}
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -13,8 +34,9 @@ const serverOptions: ServerOptions = {
 	isBrowser: false,
 };
 
+const documents = new DocumentStoreInNode(connection);
 // Start the server with the options
-startServer(connection, factory, beananagerFactory, serverOptions);
+startServer(connection, factory, documents, beananagerFactory, serverOptions);
 
 // Listen on the connection
 connection.listen();

--- a/packages/lsp-server/src/node/server.ts
+++ b/packages/lsp-server/src/node/server.ts
@@ -9,7 +9,9 @@ import { factory } from './storage';
 const connection = createConnection(ProposedFeatures.all);
 
 // Server options - will be populated by the initialization options in startServer
-const serverOptions: ServerOptions = {};
+const serverOptions: ServerOptions = {
+	isBrowser: false,
+};
 
 // Start the server with the options
 startServer(connection, factory, beananagerFactory, serverOptions);

--- a/packages/lsp-server/tsup.config.ts
+++ b/packages/lsp-server/tsup.config.ts
@@ -35,6 +35,7 @@ const nodeConfig = defineConfig({
 	noExternal: [
 		...commonConfig.noExternal,
 		'execa',
+		'fast-glob',
 	],
 });
 


### PR DESCRIPTION
# LSP Server Capability Handling and Fallback Improvements

## Summary
This PR improves the LSP server's capability handling and adds proper fallback mechanisms for both browser and Node.js environments. It also refactors the server initialization flow to be more robust and type-safe.

This will make LSP Server ready to be used in vim.

## Key Changes

### Architecture Changes
- Moved `DocumentStore` initialization outside of `startServer` to allow platform-specific implementations
- Added fallback mechanisms for when custom LSP capabilities are not available
- Introduced `DocumentStoreInNode` class for Node.js-specific implementations
- Made server options more explicit with required `isBrowser` flag

### Capability Handling
- Added proper capability checks for `ListBeanFile` and `FileRead` custom messages
- Implemented fallback methods for file operations when custom capabilities are not available:
  - `fallbackListBeanFiles`: Uses workspace folder to find bean files
  - `fallbackFileRead`: Provides platform-specific file reading implementation

### Browser Support
- Removed experimental browser notification as the implementation is now more stable
- Added proper type imports to avoid runtime dependencies
- Improved browser-specific initialization