### PR TITLE
Fix duplicate diagnostics

### DIFF
--- a/packages/lsp-client/README.md
+++ b/packages/lsp-client/README.md
@@ -121,6 +121,7 @@ git clone https://github.com/fengkx/beancount-lsp.git
 cd beancount-lsp
 
 # Install dependencies
+git submodule update --init
 pnpm install
 
 # Build all packages

--- a/packages/lsp-server/src/common/features/diagnostics.ts
+++ b/packages/lsp-server/src/common/features/diagnostics.ts
@@ -2,6 +2,7 @@ import { Logger } from '@bean-lsp/shared';
 import Big from 'big.js';
 import { Connection, Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
 import { DocumentStore } from '../document-store';
 import { Trees } from '../trees';
 import { findAllTransactions } from '../utils/ast-utils';
@@ -35,7 +36,7 @@ export class DiagnosticsFeature implements Feature {
 		private readonly trees: Trees,
 		private readonly optionsManager: BeancountOptionsManager,
 		private readonly beanMgr: RealBeancountManager | undefined,
-	) { }
+	) {}
 
 	async register(connection: Connection): Promise<void> {
 		this.logger.info('Registering diagnostics feature');
@@ -102,6 +103,15 @@ export class DiagnosticsFeature implements Feature {
 		}
 	}
 
+	private uriForDiagnostics(uri: string): string {
+		if (!this.beanMgr) {
+			return uri;
+		}
+
+		// return as file uri for better integration with beancount diagnostics
+		return 'file://' + URI.parse(uri).fsPath;
+	}
+
 	private async validateAllDocuments(connection: Connection): Promise<void> {
 		await Promise.all(
 			this.documents.all().map(async doc => {
@@ -109,7 +119,7 @@ export class DiagnosticsFeature implements Feature {
 			}),
 		);
 
-		const documentsInStore = new Set(this.documents.keys());
+		const documentsInStore = new Set(this.documents.keys().map(this.uriForDiagnostics, this));
 		await Promise.all(
 			Object.entries(this.diagnosticsFromBeancount).map(async ([uri, diagnostics]) => {
 				if (documentsInStore.has(uri)) {
@@ -170,7 +180,7 @@ export class DiagnosticsFeature implements Feature {
 		try {
 			const diagnostics = await this.provideDiagnostics(document);
 			connection.sendDiagnostics({
-				uri: document.uri,
+				uri: this.uriForDiagnostics(document.uri),
 				diagnostics,
 			});
 		} catch (err) {
@@ -185,6 +195,13 @@ export class DiagnosticsFeature implements Feature {
 		}
 
 		const diagnostics: Diagnostic[] = [];
+
+		const scheme = URI.parse(document.uri).scheme;
+
+		// We ignore git schemes because they lead to confusing diagnostics
+		if (scheme === 'git') {
+			return [];
+		}
 
 		// Find all transactions in the document
 		const transactions = findAllTransactions(tree.rootNode, document);
@@ -230,8 +247,8 @@ export class DiagnosticsFeature implements Feature {
 					const imbalanceMessages: string[] = [];
 
 					for (const imbalance of result.imbalances) {
-						const precision = imbalance.tolerance.toString().split('.')?.[1]?.length ??
-							Math.max(2, imbalance.difference.abs().toFixed().replace(/^0+\.?/, '').length);
+						const precision = imbalance.tolerance.toString().split('.')?.[1]?.length
+							?? Math.max(2, imbalance.difference.abs().toFixed().replace(/^0+\.?/, '').length);
 						const amount = imbalance.difference.toFixed(precision) || '0';
 						const currency = imbalance.currency || '';
 						imbalanceMessages.push(`${amount} ${currency}`);
@@ -252,7 +269,7 @@ export class DiagnosticsFeature implements Feature {
 			}
 		}
 
-		const beancountDiagnostics = this.diagnosticsFromBeancount[document.uri];
+		const beancountDiagnostics = this.diagnosticsFromBeancount[this.uriForDiagnostics(document.uri)];
 		if (!beancountDiagnostics) {
 			return diagnostics;
 		}
@@ -322,12 +339,12 @@ export class DiagnosticsFeature implements Feature {
 	 * Infer default tolerances from postings
 	 * Implements Beancount's default tolerance algorithm: calculate tolerance for each currency separately
 	 * Tolerance = 0.5 * (10^(-precision))
-	 * 
+	 *
 	 * Note: For the purpose of inferring tolerance, price and cost amounts are ignored.
 	 * Only the base amounts of postings are considered.
 	 * All amounts (including integers) participate in precision comparison to find the coarsest precision.
 	 * If the coarsest precision is 0 (integer), no tolerance is inferred for that currency.
-	 * 
+	 *
 	 * @param postings All postings in the transaction
 	 * @returns Tolerance mapping for each currency
 	 */
@@ -367,7 +384,7 @@ export class DiagnosticsFeature implements Feature {
 
 	/**
 	 * Get the precision of a number string (number of digits after decimal point)
-	 * 
+	 *
 	 * @param numberStr Number string
 	 * @returns Precision (number of digits after decimal point)
 	 */

--- a/packages/lsp-server/src/common/features/diagnostics.ts
+++ b/packages/lsp-server/src/common/features/diagnostics.ts
@@ -23,8 +23,8 @@ interface DiagnosticsConfig {
 	warnOnIncompleteTransaction: boolean;
 }
 
-function isFileUri(uri: string): boolean {
-	return URI.parse(uri).scheme === 'file';
+function isNotGitUri(uri: string): boolean {
+	return URI.parse(uri).scheme !== 'git';
 }
 
 export class DiagnosticsFeature implements Feature {
@@ -114,7 +114,7 @@ export class DiagnosticsFeature implements Feature {
 			}),
 		);
 
-		const documentsInStore = new Set(this.documents.keys().filter(isFileUri));
+		const documentsInStore = new Set(this.documents.keys().filter(isNotGitUri));
 		await Promise.all(
 			Object.entries(this.diagnosticsFromBeancount).map(async ([uri, diagnostics]) => {
 				if (documentsInStore.has(uri)) {
@@ -172,7 +172,7 @@ export class DiagnosticsFeature implements Feature {
 	}
 
 	private async validateDocument(document: TextDocument, connection: Connection): Promise<void> {
-		if (isFileUri(document.uri)) {
+		if (isNotGitUri(document.uri)) {
 			try {
 				const diagnostics = await this.provideDiagnostics(document);
 				connection.sendDiagnostics({


### PR DESCRIPTION
I was getting duplicate warnings when I had both the source and the git diff open in vscode. This removes the warnings from the git file if they are "duplicates". 
Duplicates are defined as same line and same severity kind, which should be good enough for now.