### PR TITLE
Avoid adding ending quote if there is one already

### DIFF
--- a/packages/lsp-server/src/common/features/completions/index.ts
+++ b/packages/lsp-server/src/common/features/completions/index.ts
@@ -1367,13 +1367,12 @@ export class CompletionFeature implements Feature {
 					symbolProvider: this.symbolIndex,
 					position: position,
 					shouldIncludePayees: true,
-					quotationStyle: 'both',
+					quotationStyle: 'none',
 					existingCompletions: set,
 					completions: completionItems,
 					completionCount: cnt,
 					filterText: userInput,
-					addSpaceAfter: true,
-					characterAfterCursor: info.characterAfterCursor,
+					addSpaceAfter: false,
 				});
 				logger.info(`Payees and narrations added, items: ${completionItems.length - initialCount}`);
 			})


### PR DESCRIPTION
This PR tries to support the case with auto-pairs for quotes. When inserting
quote, another quote is added. This language server doesn't handle this case.
It always insets another quote. I tried to preserve current behavior by
inserting quote and space. This uses TextEdit to replace the following quote
instead of inserting text before it.

Another problem is with `narration current` branch. Current behavior is adding
surrounding quotes. But this branch is triggered when I'm already inside
narration and quotes... For now I just set `quotationStyle` to none and
disabled space.

But I think this case should be completely rewritten. For example, suppose I
trigger completion in the following line (cursor is on the `|` character):

```
2025-10-19 * "Interest c|"
```

Currently language server returns every possible completion which would be
inserted at `|`, but I think that language server should return only narrations
that starts with `Interest `. In this case user can complete narration. Of
course it should handle ending quotes too. Another possibility is to return
complete list of possible completions, but TextEdit would replace the entire
narration with the new value (though this is probably not what user expects).

I'm not planning to implement it in this PR. Maybe later.
