### PR TITLE
feat: rename documents along with accounts

### DIFF
--- a/packages/lsp-client/src/common/client.ts
+++ b/packages/lsp-client/src/common/client.ts
@@ -232,6 +232,7 @@ export function setupCustomMessageHandlers(ctx: ExtensionContext<'browser' | 'no
 		params.capabilities['customMessage'] = {
 			[CustomMessages.ListBeanFile]: true,
 			[CustomMessages.FileRead]: true,
+			[CustomMessages.FindFiles]: true,
 		};
 		return originalInitialize(connection, params);
 	};
@@ -243,6 +244,11 @@ export function setupCustomMessageHandlers(ctx: ExtensionContext<'browser' | 'no
 			return f.toString();
 		});
 		return uriStrings;
+	});
+
+	ctx.client.onRequest(CustomMessages.FindFiles, async (pattern: string) => {
+		const files = await vscode.workspace.findFiles(pattern);
+		return files.map(f => f.toString());
 	});
 
 	ctx.client.onRequest(CustomMessages.FileRead, async (raw: string): Promise<number[]> => {

--- a/packages/lsp-server/src/common/document-store.ts
+++ b/packages/lsp-server/src/common/document-store.ts
@@ -137,6 +137,20 @@ export class DocumentStore extends TextDocuments<TextDocument> {
 		return new ArrayBuffer(0);
 	}
 
+	async findFiles(pattern: string): Promise<string[]> {
+		// Check if client supports FindFiles capability
+		// @ts-expect-error customMessage is not part of the protocol
+		if (!this._initializeParams?.capabilities?.customMessage?.[CustomMessages.FindFiles]) {
+			return this.fallbackFindFiles(pattern);
+		}
+		return this._connection.sendRequest<string[]>(CustomMessages.FindFiles, pattern);
+	}
+
+	protected async fallbackFindFiles(_pattern: string): Promise<string[]> {
+		this.logger.warn('Client does not support FindFiles capability');
+		return [];
+	}
+
 	removeFile(uri: string): boolean {
 		return this._documentsCache.delete(uri);
 	}

--- a/packages/lsp-server/src/common/utils/beancount-options.ts
+++ b/packages/lsp-server/src/common/utils/beancount-options.ts
@@ -7,7 +7,7 @@ import { parseExpression } from './expression-parser';
 // Create a logger for the options manager
 const logger = new Logger('BeancountOptions');
 
-export type SupportedOption = 'infer_tolerance_from_cost' | 'inferred_tolerance_multiplier';
+export type SupportedOption = 'infer_tolerance_from_cost' | 'inferred_tolerance_multiplier' | 'documents';
 type OptionKeys = LiteralUnion<SupportedOption, string>;
 
 /**

--- a/packages/lsp-server/src/node/server.ts
+++ b/packages/lsp-server/src/node/server.ts
@@ -25,6 +25,11 @@ class DocumentStoreInNode extends DocumentStore {
 		new Uint8Array(ab).set(buffer);
 		return ab;
 	}
+
+	protected override async fallbackFindFiles(pattern: string): Promise<string[]> {
+		const files = await glob(pattern, { absolute: true })
+		return files.map((p) => pathToFileURL(p).toString());
+	}
 }
 
 // Create a connection for the server, using Node's IPC as a transport.

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -4,6 +4,7 @@ import { BQL_COLUMNS, BQL_FUNCTIONS } from './constraint/bean-query-doc';
 export const CustomMessages = {
 	FileRead: 'beanLspCustom/fileRead' as const,
 	ListBeanFile: 'beanLsPCustom/listBeanFile' as const,
+	FindFiles: 'beanLsPCustom/findFiles' as const,
 	QueueInit: 'beanLspCustom/queueInit' as const,
 	GetAccounts: 'beanLspCustom/getAccounts' as const,
 	GetPayees: 'beanLspCustom/getPayees' as const,


### PR DESCRIPTION
This PR tries to implement document renaming along with accounts.

Closes: #138.

This introduces a new DocumentStore method for finding files. It's implemented similar to ListBeanFiles. This was the only thing I came up with to support both browser and nodejs. Potentially, in the future this method could be extended to support excludes and re-used in `refetchBeanFiles`.

NOTE: *browser is untested*. I tested functionality only in lsp-server. Not client, nor browser.

This PR for now is as proof of concept. I pushed it to know if this is suitable.

There are a shortcomings:

- It uses `getOption` method to get the option value. But this method doesn't support lists. `documents` option works only in main beancount file. And this option can be specified multiple times. In this case it's value is a list of directories. This PR as of now only looks for documents in the directory returned by `getOption`. Also in beancount this option works only when specified in the main file, not from included files, but if it specified multiple time, `getOption` would return only one random directory, if I understand correctly.
- For now it tests if the directory is absolute path by testing if it starts with `/`. I need to replace it with something portable and universal.