### PR TITLE
fix: add missing prepare rename for links

### DIFF
--- a/packages/lsp-server/src/common/features/rename.ts
+++ b/packages/lsp-server/src/common/features/rename.ts
@@ -88,6 +88,16 @@ export class RenameFeature {
 			};
 		}
 
+		// Check for link at position
+		const linkAtPosition = await positionUtils.getLinkAtPosition(this.trees, document, params.position);
+		if (linkAtPosition) {
+			logger.debug(`Found renamable link at position: ${linkAtPosition}`);
+			return {
+				range,
+				placeholder: textAtRange, // Use exact text from document
+			};
+		}
+
 		// Check for payee at position
 		const payeeAtPosition = await positionUtils.getPayeeAtPosition(this.trees, document, params.position);
 		if (payeeAtPosition) {


### PR DESCRIPTION
This PR adds missing support for `prepareRename` on links.
