### PR TITLE
refactor: lower priority of a log message sending document text

### DIFF
--- a/packages/lsp-server/src/common/trees.ts
+++ b/packages/lsp-server/src/common/trees.ts
@@ -85,7 +85,7 @@ export class Trees {
 			console.error(
 				`[trees] Error parsing document: ${documentOrUri.uri} ${errorObj} ${errorObj.stack || ''}`,
 			);
-			console.error(`[trees] Error parsing text: ${documentOrUri.getText()}`);
+			console.debug(`[trees] Error parsing text: ${documentOrUri.getText()}`);
 			this._cache.delete(documentOrUri.uri);
 			return undefined;
 		}


### PR DESCRIPTION
I have a pretty large text document and sending it entirely to logs is too much. I have a couple of messages from this line every startup and it inflates logs too much. At least lower the priority to debug.
